### PR TITLE
[CSL-1803]  Bump LTS version to 9.14, so it uses ghc-8.0.2, which is available in Nixpkgs

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -7,7 +7,7 @@ packages:
 
 extra-deps: []
 
-resolver: lts-7.14
+resolver: lts-9.14
 
 nix:
     packages: [rocksdb,gmp]


### PR DESCRIPTION
The LTS bump makes the Nix integration refer to GHC `8.0.2`, instead of `8.0.1`, which is no longer defined there.