### PR TITLE
Turning segfaults into exceptions with high probability

### DIFF
--- a/rocksdb-haskell.cabal
+++ b/rocksdb-haskell.cabal
@@ -71,4 +71,5 @@ test-suite rocksdb-tests
                      , temporary
                      , hspec-expectations
                      , QuickCheck
+                     , directory
   default-language:    Haskell2010

--- a/rocksdb-haskell.cabal
+++ b/rocksdb-haskell.cabal
@@ -64,6 +64,7 @@ test-suite rocksdb-tests
                      , hspec >= 1.8
                      , process >= 1.1.0.2
                      , bytestring >= 0.10.4.0
+                     , async
                      , data-default
                      , filepath
                      , resourcet

--- a/rocksdb-haskell.cabal
+++ b/rocksdb-haskell.cabal
@@ -65,6 +65,7 @@ test-suite rocksdb-tests
                      , process >= 1.1.0.2
                      , bytestring >= 0.10.4.0
                      , data-default
+                     , filepath
                      , resourcet
                      , transformers
                      , temporary

--- a/src/Database/RocksDB/Base.hs
+++ b/src/Database/RocksDB/Base.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP           #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TupleSections #-}
 
 -- |
@@ -34,8 +35,11 @@ module Database.RocksDB.Base
     , defaultWriteOptions
 
     -- * Basic Database Manipulations
+    , withDB
     , open
+    , openAutoclose
     , openBracket
+    , finalize
     , close
     , put
     , putBinaryVal
@@ -68,7 +72,7 @@ module Database.RocksDB.Base
     ) where
 
 import           Control.Applicative          ((<$>))
-import           Control.Exception            (bracket, bracketOnError, finally)
+import           Control.Exception            (bracket, bracketOnError, finally, mask_)
 import           Control.Monad                (liftM, when)
 
 import           Control.Monad.IO.Class       (MonadIO (liftIO))
@@ -79,8 +83,10 @@ import qualified Data.Binary                  as Binary
 import           Data.ByteString              (ByteString)
 import           Data.ByteString.Internal     (ByteString (..))
 import qualified Data.ByteString.Lazy         as BSL
+import           Data.IORef                   (newIORef, atomicWriteIORef)
 import           Foreign
 import           Foreign.C.String             (CString, withCString)
+import           GHC.Stack                    (HasCallStack)
 import           System.Directory             (createDirectoryIfMissing)
 
 import           Database.RocksDB.C
@@ -107,6 +113,11 @@ bloomFilter i =
 openBracket :: MonadResource m => FilePath -> Options -> m (ReleaseKey, DB)
 openBracket path opts = allocate (open path opts) close
 {-# INLINE openBracket #-}
+-- Note that in the above, we don't get double-close detection
+-- (see comment on `DB`), because apparently `runResourceT` swallows
+-- any `error` that we may raise in the cleanup function given to
+-- allocate. So if our double-close detection `error` triggers in
+-- `close`, the user will not see it.
 
 -- | Run an action with a snapshot of the database.
 --
@@ -132,7 +143,11 @@ createSnapshotBracket db = allocate (createSnapshot db) (releaseSnapshot db)
 
 -- | Open a database.
 --
--- The returned handle should be released with 'close'.
+-- The returned handle must be released with 'close', or
+-- it will memory leak.
+--
+-- The `ForeignPtr` in the returned `DB` does not have a
+-- finalizer attached.
 --
 -- This function is not async-exception-safe.
 -- If interrupted by an async exceptions, the resources acquired
@@ -140,16 +155,16 @@ createSnapshotBracket db = allocate (createSnapshot db) (releaseSnapshot db)
 -- Thus it should be used only within `bracket` or a similar function
 -- so that a finalizer calling `close` can be attached while async
 -- exceptions are disabled.
-open :: MonadIO m => FilePath -> Options -> m DB
-open path opts = liftIO $ bracketOnError initialize finalize mkDB
+open :: (HasCallStack, MonadIO m) => FilePath -> Options -> m DB
+open path opts = liftIO $ bracketOnError initializeOpts finalizeOpts mkDB
     where
 # ifdef mingw32_HOST_OS
-        initialize =
+        initializeOpts =
             (, ()) <$> mkOpts opts
-        finalize (opts', ()) =
+        finalizeOpts (opts', ()) =
             freeOpts opts'
 # else
-        initialize = do
+        initializeOpts = do
             opts' <- mkOpts opts
             -- With LC_ALL=C, two things happen:
             --   * rocksdb can't open a database with unicode in path;
@@ -161,17 +176,87 @@ open path opts = liftIO $ bracketOnError initialize finalize mkDB
             when (createIfMissing opts) $
                 GHC.setFileSystemEncoding GHC.utf8
             pure (opts', oldenc)
-        finalize (opts', oldenc) = do
+        finalizeOpts (opts', oldenc) = do
             freeOpts opts'
             GHC.setFileSystemEncoding oldenc
 # endif
         mkDB (opts'@(Options' opts_ptr _ _), _) = do
             when (createIfMissing opts) $
                 createDirectoryIfMissing True path
-            withFilePath path $ \path_ptr ->
-                liftM (`DB` opts')
-                $ throwIfErr "open"
-                $ c_rocksdb_open opts_ptr path_ptr
+            withFilePath path $ \path_ptr -> do
+                bracketOnError
+                    (do
+                        db_ptr <- throwIfErr "open" $ c_rocksdb_open opts_ptr path_ptr
+                        statusRef <- newIORef Open
+                        db_fptr <- newForeignPtr_ db_ptr
+                        return $ DB
+                            { db_fptr
+                            , dbOptions = opts'
+                            , dbHandleStatusRef = statusRef
+                            , dbAutoclose = False
+                            }
+                    )
+                    (\DB{ db_fptr, dbOptions, dbHandleStatusRef } -> do
+                        atomicWriteIORef dbHandleStatusRef Closed
+                        finalizeForeignPtr db_fptr `finally` freeOpts dbOptions
+                    )
+                    return
+
+-- | Like open, but the DB will be auto-closed when the
+-- returned `DB` gets garbage-collected.
+--
+-- This function is async-exception safe.
+--
+-- You must not call `close` on the returned handle.
+--
+-- If you want to promptly close the handle, use `finalize`
+-- instead. After you have called `finalize` on the handle,
+-- you must no longer use it for any DB operation.
+--
+-- Note it is still not recommended to use this without
+-- explicit `finalize` because if you want to open the same
+-- database again from the same process, you may run into the
+-- issue that the GC has not yet run `finalize` for you, and
+-- RocksDB has a global state of what DBs are opened
+-- (see https://stackoverflow.com/questions/37310588/rocksdb-io-error-lock-no-locks-available#comment83145041_37312033),
+-- so code like the following may fail with a lock error:
+--
+-- > db1 <- openAutoclose "/path/to/db" ...
+-- > ...
+-- > -- db1 goes out of scope here
+-- > db2 <- openAutoclose "/path/to/db" ...
+-- > -- ^ the above may fail with a lock error if the GC hasn't run
+--
+-- This can be fixed by running `finalize db1` when you're
+-- really done with the DB.
+--
+-- The safest way to do so is to use a bracketing function like `withDB`,
+-- `openBracket` which uses `MonadResource` to close the DB promptly.
+openAutoclose :: (HasCallStack, MonadIO m) => FilePath -> Options -> m DB
+openAutoclose path opts = liftIO $ do
+    mask_ $ do
+        db <- open path opts
+        addForeignPtrFinalizer c_rocksdb_close_funptr (db_fptr db)
+        return $ db{ dbAutoclose = True }
+
+-- | The simplest and safest way to use a DB.
+--
+-- The DB is closed when this function returns.
+--
+-- You must not return the DB out of the inner scope.
+--
+-- You must not call `close` on the DB.
+--
+-- You may call `finalize` on the DB to close it before
+-- `withDB` returns if you know that no
+-- other DB operation will be performed afterwards,
+-- or is performing in another thread concurrently.
+withDB :: (HasCallStack) => FilePath -> Options -> (DB -> IO a) -> IO a
+withDB path opts f = do
+    bracket
+        (open path opts)
+        close
+        f
 
 -- | Close a database.
 --
@@ -181,41 +266,60 @@ open path opts = liftIO $ bracketOnError initialize finalize mkDB
 -- the program will SEGFAULT.
 -- If another RocksDB operation is still running in another thread while
 -- close() is function is called, this may results in crashes or data loss.
-close :: MonadIO m => DB -> m ()
-close (DB db_ptr opts_ptr) = liftIO $
-    c_rocksdb_close db_ptr `finally` freeOpts opts_ptr
+close :: (MonadIO m, HasCallStack) => DB -> m ()
+close db@DB{ db_fptr, dbOptions, dbAutoclose } = liftIO $ do
+    when dbAutoclose $ do
+        error $ "haskell-rocksdb close: Caller BUG: DB opened with 'openAutoclose' must not be closed manually"
+    ensureOpenAndClose db
+    withForeignPtr db_fptr $ \db_ptr -> do
+        c_rocksdb_close db_ptr `finally` freeOpts dbOptions
 
+-- | Like `close`, but it is not an error to call this function
+-- multiple times on the same `DB` handle.
+--
+-- This function should be called on DB handles opened with
+-- `openAutoclose`. It has no effect on handles opened with
+-- plain `open`.
+finalize :: MonadIO m => DB -> m ()
+finalize DB{ db_fptr } = liftIO $
+    finalizeForeignPtr db_fptr
 
 -- | Run an action with a 'Snapshot' of the database.
-withSnapshot :: MonadIO m => DB -> (Snapshot -> IO a) -> m a
+withSnapshot :: (MonadIO m, HasCallStack) => DB -> (Snapshot -> IO a) -> m a
 withSnapshot db act = liftIO $
     bracket (createSnapshot db) (releaseSnapshot db) act
 
 -- | Create a snapshot of the database.
 --
 -- The returned 'Snapshot' should be released with 'releaseSnapshot'.
-createSnapshot :: MonadIO m => DB -> m Snapshot
-createSnapshot (DB db_ptr _) = liftIO $
-    Snapshot <$> c_rocksdb_create_snapshot db_ptr
+createSnapshot :: (MonadIO m, HasCallStack) => DB -> m Snapshot
+createSnapshot db@DB{ db_fptr } = liftIO $ do
+    ensureOpen db
+    withForeignPtr db_fptr $ \db_ptr ->
+        Snapshot <$> c_rocksdb_create_snapshot db_ptr
 
 -- | Release a snapshot.
 --
 -- The handle will be invalid after calling this action and should no
 -- longer be used.
-releaseSnapshot :: MonadIO m => DB -> Snapshot -> m ()
-releaseSnapshot (DB db_ptr _) (Snapshot snap) = liftIO $
-    c_rocksdb_release_snapshot db_ptr snap
+releaseSnapshot :: (MonadIO m, HasCallStack) => DB -> Snapshot -> m ()
+releaseSnapshot db@DB{ db_fptr } (Snapshot snap) = liftIO $ do
+    ensureOpen db
+    withForeignPtr db_fptr $ \db_ptr ->
+        c_rocksdb_release_snapshot db_ptr snap
 
 -- | Get a DB property.
-getProperty :: MonadIO m => DB -> Property -> m (Maybe ByteString)
-getProperty (DB db_ptr _) p = liftIO $
-    withCString (prop p) $ \prop_ptr -> do
-        val_ptr <- c_rocksdb_property_value db_ptr prop_ptr
-        if val_ptr == nullPtr
-            then return Nothing
-            else do res <- Just <$> BS.packCString val_ptr
-                    freeCString val_ptr
-                    return res
+getProperty :: (MonadIO m, HasCallStack) => DB -> Property -> m (Maybe ByteString)
+getProperty db@DB{ db_fptr } p = liftIO $ do
+    ensureOpen db
+    withForeignPtr db_fptr $ \db_ptr -> do
+        withCString (prop p) $ \prop_ptr -> do
+            val_ptr <- c_rocksdb_property_value db_ptr prop_ptr
+            if val_ptr == nullPtr
+                then return Nothing
+                else do res <- Just <$> BS.packCString val_ptr
+                        freeCString val_ptr
+                        return res
     where
         prop (NumFilesAtLevel i) = "rocksdb.num-files-at-level" ++ show i
         prop Stats               = "rocksdb.stats"
@@ -242,20 +346,22 @@ repair path opts = liftIO $ bracket (mkOpts opts) freeOpts repair'
 type Range  = (ByteString, ByteString)
 
 -- | Inspect the approximate sizes of the different levels.
-approximateSize :: MonadIO m => DB -> Range -> m Int64
-approximateSize (DB db_ptr _) (from, to) = liftIO $
-    BU.unsafeUseAsCStringLen from $ \(from_ptr, flen) ->
-    BU.unsafeUseAsCStringLen to   $ \(to_ptr, tlen)   ->
-    withArray [from_ptr]          $ \from_ptrs        ->
-    withArray [intToCSize flen]   $ \flen_ptrs        ->
-    withArray [to_ptr]            $ \to_ptrs          ->
-    withArray [intToCSize tlen]   $ \tlen_ptrs        ->
-    allocaArray 1                 $ \size_ptrs        -> do
-        c_rocksdb_approximate_sizes db_ptr 1
-                                    from_ptrs flen_ptrs
-                                    to_ptrs tlen_ptrs
-                                    size_ptrs
-        liftM head $ peekArray 1 size_ptrs >>= mapM toInt64
+approximateSize :: (MonadIO m, HasCallStack) => DB -> Range -> m Int64
+approximateSize db@DB{ db_fptr } (from, to) = liftIO $ do
+    ensureOpen db
+    withForeignPtr db_fptr $ \db_ptr ->
+        BU.unsafeUseAsCStringLen from $ \(from_ptr, flen) ->
+        BU.unsafeUseAsCStringLen to   $ \(to_ptr, tlen)   ->
+        withArray [from_ptr]          $ \from_ptrs        ->
+        withArray [intToCSize flen]   $ \flen_ptrs        ->
+        withArray [to_ptr]            $ \to_ptrs          ->
+        withArray [intToCSize tlen]   $ \tlen_ptrs        ->
+        allocaArray 1                 $ \size_ptrs        -> do
+            c_rocksdb_approximate_sizes db_ptr 1
+                                        from_ptrs flen_ptrs
+                                        to_ptrs tlen_ptrs
+                                        size_ptrs
+            liftM head $ peekArray 1 size_ptrs >>= mapM toInt64
 
     where
         toInt64 = return . fromIntegral
@@ -267,14 +373,16 @@ putBinary :: (MonadIO m, Binary k, Binary v) => DB -> WriteOptions -> k -> v -> 
 putBinary db wopts key val = put db wopts (binaryToBS key) (binaryToBS val)
 
 -- | Write a key/value pair.
-put :: MonadIO m => DB -> WriteOptions -> ByteString -> ByteString -> m ()
-put (DB db_ptr _) opts key value = liftIO $ withCWriteOpts opts $ \opts_ptr ->
-    BU.unsafeUseAsCStringLen key   $ \(key_ptr, klen) ->
-    BU.unsafeUseAsCStringLen value $ \(val_ptr, vlen) ->
-        throwIfErr "put"
-            $ c_rocksdb_put db_ptr opts_ptr
-                            key_ptr (intToCSize klen)
-                            val_ptr (intToCSize vlen)
+put :: (MonadIO m, HasCallStack) => DB -> WriteOptions -> ByteString -> ByteString -> m ()
+put db@DB{ db_fptr } opts key value = liftIO $ withCWriteOpts opts $ \opts_ptr -> do
+    ensureOpen db
+    withForeignPtr db_fptr $ \db_ptr ->
+        BU.unsafeUseAsCStringLen key   $ \(key_ptr, klen) ->
+        BU.unsafeUseAsCStringLen value $ \(val_ptr, vlen) ->
+            throwIfErr "put"
+                $ c_rocksdb_put db_ptr opts_ptr
+                                key_ptr (intToCSize klen)
+                                val_ptr (intToCSize vlen)
 
 getBinaryVal :: (Binary v, MonadIO m) => DB -> ReadOptions -> ByteString -> m (Maybe v)
 getBinaryVal db ropts key  = fmap bsToBinary <$> get db ropts key
@@ -283,35 +391,41 @@ getBinary :: (MonadIO m, Binary k, Binary v) => DB -> ReadOptions -> k -> m (May
 getBinary db ropts key = fmap bsToBinary <$> get db ropts (binaryToBS key)
 
 -- | Read a value by key.
-get :: MonadIO m => DB -> ReadOptions -> ByteString -> m (Maybe ByteString)
-get (DB db_ptr _) opts key = liftIO $ withCReadOpts opts $ \opts_ptr ->
-    BU.unsafeUseAsCStringLen key $ \(key_ptr, klen) ->
-    alloca                       $ \vlen_ptr -> do
-        val_ptr <- throwIfErr "get" $
-            c_rocksdb_get db_ptr opts_ptr key_ptr (intToCSize klen) vlen_ptr
-        vlen <- peek vlen_ptr
-        if val_ptr == nullPtr
-            then return Nothing
-            else do
-                res' <- Just <$> BS.packCStringLen (val_ptr, cSizeToInt vlen)
-                freeCString val_ptr
-                return res'
+get :: (MonadIO m, HasCallStack) => DB -> ReadOptions -> ByteString -> m (Maybe ByteString)
+get db@DB{ db_fptr } opts key = liftIO $ withCReadOpts opts $ \opts_ptr -> do
+    ensureOpen db
+    withForeignPtr db_fptr $ \db_ptr ->
+        BU.unsafeUseAsCStringLen key $ \(key_ptr, klen) ->
+        alloca                       $ \vlen_ptr -> do
+            val_ptr <- throwIfErr "get" $
+                c_rocksdb_get db_ptr opts_ptr key_ptr (intToCSize klen) vlen_ptr
+            vlen <- peek vlen_ptr
+            if val_ptr == nullPtr
+                then return Nothing
+                else do
+                    res' <- Just <$> BS.packCStringLen (val_ptr, cSizeToInt vlen)
+                    freeCString val_ptr
+                    return res'
 
 -- | Delete a key/value pair.
-delete :: MonadIO m => DB -> WriteOptions -> ByteString -> m ()
-delete (DB db_ptr _) opts key = liftIO $ withCWriteOpts opts $ \opts_ptr ->
-    BU.unsafeUseAsCStringLen key $ \(key_ptr, klen) ->
-        throwIfErr "delete"
-            $ c_rocksdb_delete db_ptr opts_ptr key_ptr (intToCSize klen)
+delete :: (MonadIO m, HasCallStack) => DB -> WriteOptions -> ByteString -> m ()
+delete db@DB{ db_fptr } opts key = liftIO $ withCWriteOpts opts $ \opts_ptr -> do
+    ensureOpen db
+    withForeignPtr db_fptr $ \db_ptr ->
+        BU.unsafeUseAsCStringLen key $ \(key_ptr, klen) ->
+            throwIfErr "delete"
+                $ c_rocksdb_delete db_ptr opts_ptr key_ptr (intToCSize klen)
 
 -- | Perform a batch mutation.
-write :: MonadIO m => DB -> WriteOptions -> WriteBatch -> m ()
-write (DB db_ptr _) opts batch = liftIO $ withCWriteOpts opts $ \opts_ptr ->
-    bracket c_rocksdb_writebatch_create c_rocksdb_writebatch_destroy $ \batch_ptr -> do
+write :: (MonadIO m, HasCallStack) => DB -> WriteOptions -> WriteBatch -> m ()
+write db@DB{ db_fptr } opts batch = liftIO $ withCWriteOpts opts $ \opts_ptr -> do
+    ensureOpen db
+    withForeignPtr db_fptr $ \db_ptr ->
+        bracket c_rocksdb_writebatch_create c_rocksdb_writebatch_destroy $ \batch_ptr -> do
 
-    mapM_ (batchAdd batch_ptr) batch
+        mapM_ (batchAdd batch_ptr) batch
 
-    throwIfErr "write" $ c_rocksdb_write db_ptr opts_ptr batch_ptr
+        throwIfErr "write" $ c_rocksdb_write db_ptr opts_ptr batch_ptr
 
     -- ensure @ByteString@s (and respective shared @CStringLen@s) aren't GC'ed
     -- until here

--- a/src/Database/RocksDB/Base.hs
+++ b/src/Database/RocksDB/Base.hs
@@ -107,15 +107,13 @@ bloomFilter i =
 -- | Open a database
 --
 -- The returned handle will automatically be released when the enclosing
--- 'runResourceT' terminates.
+-- 'runResourceTChecked' terminates.
+--
+-- Note that if you use `runResourceT` instead of `runResourceTChecked`,
+-- you won't get double-close detection.
 openBracket :: MonadResource m => FilePath -> Options -> m (ReleaseKey, DB)
 openBracket path opts = allocate (open path opts) close
 {-# INLINE openBracket #-}
--- Note that in the above, we don't get double-close detection
--- (see comment on `DB`), because apparently `runResourceT` swallows
--- any `error` that we may raise in the cleanup function given to
--- allocate. So if our double-close detection `error` triggers in
--- `close`, the user will not see it.
 
 -- | Run an action with a snapshot of the database.
 --
@@ -133,7 +131,7 @@ withSnapshotBracket db f = do
 -- | Create a snapshot of the database.
 --
 -- The returned 'Snapshot' will be released automatically when the enclosing
--- 'runResourceT' terminates. It is recommended to use 'createSnapshot'' instead
+-- 'runResourceTChecked' terminates. It is recommended to use 'createSnapshot'' instead
 -- and release the resource manually as soon as possible.
 -- Can be released early.
 createSnapshotBracket :: MonadResource m => DB -> m (ReleaseKey, Snapshot)

--- a/src/Database/RocksDB/Base.hs
+++ b/src/Database/RocksDB/Base.hs
@@ -177,6 +177,10 @@ open path opts = liftIO $ bracketOnError initialize finalize mkDB
 --
 -- The handle will be invalid after calling this action and should no
 -- longer be used.
+-- If it is used, with the current implementation of RocksDB,
+-- the program will SEGFAULT.
+-- If another RocksDB operation is still running in another thread while
+-- close() is function is called, this may results in crashes or data loss.
 close :: MonadIO m => DB -> m ()
 close (DB db_ptr opts_ptr) = liftIO $
     c_rocksdb_close db_ptr `finally` freeOpts opts_ptr

--- a/src/Database/RocksDB/Base.hs
+++ b/src/Database/RocksDB/Base.hs
@@ -37,9 +37,7 @@ module Database.RocksDB.Base
     -- * Basic Database Manipulations
     , withDB
     , open
-    , openAutoclose
     , openBracket
-    , finalize
     , close
     , put
     , putBinaryVal
@@ -72,7 +70,7 @@ module Database.RocksDB.Base
     ) where
 
 import           Control.Applicative          ((<$>))
-import           Control.Exception            (bracket, bracketOnError, finally, mask_)
+import           Control.Exception            (bracket, bracketOnError, finally)
 import           Control.Monad                (liftM, when)
 
 import           Control.Monad.IO.Class       (MonadIO (liftIO))
@@ -83,7 +81,7 @@ import qualified Data.Binary                  as Binary
 import           Data.ByteString              (ByteString)
 import           Data.ByteString.Internal     (ByteString (..))
 import qualified Data.ByteString.Lazy         as BSL
-import           Data.IORef                   (newIORef, atomicWriteIORef)
+import           Data.IORef                   (newIORef)
 import           Foreign
 import           Foreign.C.String             (CString, withCString)
 import           GHC.Stack                    (HasCallStack)
@@ -146,9 +144,6 @@ createSnapshotBracket db = allocate (createSnapshot db) (releaseSnapshot db)
 -- The returned handle must be released with 'close', or
 -- it will memory leak.
 --
--- The `ForeignPtr` in the returned `DB` does not have a
--- finalizer attached.
---
 -- This function is not async-exception-safe.
 -- If interrupted by an async exceptions, the resources acquired
 -- by this function will memory-leak.
@@ -184,60 +179,13 @@ open path opts = liftIO $ bracketOnError initializeOpts finalizeOpts mkDB
             when (createIfMissing opts) $
                 createDirectoryIfMissing True path
             withFilePath path $ \path_ptr -> do
-                bracketOnError
-                    (do
-                        db_ptr <- throwIfErr "open" $ c_rocksdb_open opts_ptr path_ptr
-                        statusRef <- newIORef Open
-                        db_fptr <- newForeignPtr_ db_ptr
-                        return $ DB
-                            { db_fptr
-                            , dbOptions = opts'
-                            , dbHandleStatusRef = statusRef
-                            , dbAutoclose = False
-                            }
-                    )
-                    (\DB{ db_fptr, dbOptions, dbHandleStatusRef } -> do
-                        atomicWriteIORef dbHandleStatusRef Closed
-                        finalizeForeignPtr db_fptr `finally` freeOpts dbOptions
-                    )
-                    return
-
--- | Like open, but the DB will be auto-closed when the
--- returned `DB` gets garbage-collected.
---
--- This function is async-exception safe.
---
--- You must not call `close` on the returned handle.
---
--- If you want to promptly close the handle, use `finalize`
--- instead. After you have called `finalize` on the handle,
--- you must no longer use it for any DB operation.
---
--- Note it is still not recommended to use this without
--- explicit `finalize` because if you want to open the same
--- database again from the same process, you may run into the
--- issue that the GC has not yet run `finalize` for you, and
--- RocksDB has a global state of what DBs are opened
--- (see https://stackoverflow.com/questions/37310588/rocksdb-io-error-lock-no-locks-available#comment83145041_37312033),
--- so code like the following may fail with a lock error:
---
--- > db1 <- openAutoclose "/path/to/db" ...
--- > ...
--- > -- db1 goes out of scope here
--- > db2 <- openAutoclose "/path/to/db" ...
--- > -- ^ the above may fail with a lock error if the GC hasn't run
---
--- This can be fixed by running `finalize db1` when you're
--- really done with the DB.
---
--- The safest way to do so is to use a bracketing function like `withDB`,
--- `openBracket` which uses `MonadResource` to close the DB promptly.
-openAutoclose :: (HasCallStack, MonadIO m) => FilePath -> Options -> m DB
-openAutoclose path opts = liftIO $ do
-    mask_ $ do
-        db <- open path opts
-        addForeignPtrFinalizer c_rocksdb_close_funptr (db_fptr db)
-        return $ db{ dbAutoclose = True }
+                db_ptr <- throwIfErr "open" $ c_rocksdb_open opts_ptr path_ptr
+                statusRef <- newIORef Open
+                return $ DB
+                    { db_ptr
+                    , dbOptions = opts'
+                    , dbHandleStatusRef = statusRef
+                    }
 
 -- | The simplest and safest way to use a DB.
 --
@@ -246,11 +194,6 @@ openAutoclose path opts = liftIO $ do
 -- You must not return the DB out of the inner scope.
 --
 -- You must not call `close` on the DB.
---
--- You may call `finalize` on the DB to close it before
--- `withDB` returns if you know that no
--- other DB operation will be performed afterwards,
--- or is performing in another thread concurrently.
 withDB :: (HasCallStack) => FilePath -> Options -> (DB -> IO a) -> IO a
 withDB path opts f = do
     bracket
@@ -267,22 +210,9 @@ withDB path opts f = do
 -- If another RocksDB operation is still running in another thread while
 -- close() is function is called, this may results in crashes or data loss.
 close :: (MonadIO m, HasCallStack) => DB -> m ()
-close db@DB{ db_fptr, dbOptions, dbAutoclose } = liftIO $ do
-    when dbAutoclose $ do
-        error $ "haskell-rocksdb close: Caller BUG: DB opened with 'openAutoclose' must not be closed manually"
+close db@DB{ db_ptr, dbOptions } = liftIO $ do
     ensureOpenAndClose db
-    withForeignPtr db_fptr $ \db_ptr -> do
-        c_rocksdb_close db_ptr `finally` freeOpts dbOptions
-
--- | Like `close`, but it is not an error to call this function
--- multiple times on the same `DB` handle.
---
--- This function should be called on DB handles opened with
--- `openAutoclose`. It has no effect on handles opened with
--- plain `open`.
-finalize :: MonadIO m => DB -> m ()
-finalize DB{ db_fptr } = liftIO $
-    finalizeForeignPtr db_fptr
+    c_rocksdb_close db_ptr `finally` freeOpts dbOptions
 
 -- | Run an action with a 'Snapshot' of the database.
 withSnapshot :: (MonadIO m, HasCallStack) => DB -> (Snapshot -> IO a) -> m a
@@ -293,33 +223,30 @@ withSnapshot db act = liftIO $
 --
 -- The returned 'Snapshot' should be released with 'releaseSnapshot'.
 createSnapshot :: (MonadIO m, HasCallStack) => DB -> m Snapshot
-createSnapshot db@DB{ db_fptr } = liftIO $ do
+createSnapshot db@DB{ db_ptr } = liftIO $ do
     ensureOpen db
-    withForeignPtr db_fptr $ \db_ptr ->
-        Snapshot <$> c_rocksdb_create_snapshot db_ptr
+    Snapshot <$> c_rocksdb_create_snapshot db_ptr
 
 -- | Release a snapshot.
 --
 -- The handle will be invalid after calling this action and should no
 -- longer be used.
 releaseSnapshot :: (MonadIO m, HasCallStack) => DB -> Snapshot -> m ()
-releaseSnapshot db@DB{ db_fptr } (Snapshot snap) = liftIO $ do
+releaseSnapshot db@DB{ db_ptr } (Snapshot snap) = liftIO $ do
     ensureOpen db
-    withForeignPtr db_fptr $ \db_ptr ->
-        c_rocksdb_release_snapshot db_ptr snap
+    c_rocksdb_release_snapshot db_ptr snap
 
 -- | Get a DB property.
 getProperty :: (MonadIO m, HasCallStack) => DB -> Property -> m (Maybe ByteString)
-getProperty db@DB{ db_fptr } p = liftIO $ do
+getProperty db@DB{ db_ptr } p = liftIO $ do
     ensureOpen db
-    withForeignPtr db_fptr $ \db_ptr -> do
-        withCString (prop p) $ \prop_ptr -> do
-            val_ptr <- c_rocksdb_property_value db_ptr prop_ptr
-            if val_ptr == nullPtr
-                then return Nothing
-                else do res <- Just <$> BS.packCString val_ptr
-                        freeCString val_ptr
-                        return res
+    withCString (prop p) $ \prop_ptr -> do
+        val_ptr <- c_rocksdb_property_value db_ptr prop_ptr
+        if val_ptr == nullPtr
+            then return Nothing
+            else do res <- Just <$> BS.packCString val_ptr
+                    freeCString val_ptr
+                    return res
     where
         prop (NumFilesAtLevel i) = "rocksdb.num-files-at-level" ++ show i
         prop Stats               = "rocksdb.stats"
@@ -347,10 +274,9 @@ type Range  = (ByteString, ByteString)
 
 -- | Inspect the approximate sizes of the different levels.
 approximateSize :: (MonadIO m, HasCallStack) => DB -> Range -> m Int64
-approximateSize db@DB{ db_fptr } (from, to) = liftIO $ do
+approximateSize db@DB{ db_ptr } (from, to) = liftIO $ do
     ensureOpen db
-    withForeignPtr db_fptr $ \db_ptr ->
-        BU.unsafeUseAsCStringLen from $ \(from_ptr, flen) ->
+    BU.unsafeUseAsCStringLen from $ \(from_ptr, flen) ->
         BU.unsafeUseAsCStringLen to   $ \(to_ptr, tlen)   ->
         withArray [from_ptr]          $ \from_ptrs        ->
         withArray [intToCSize flen]   $ \flen_ptrs        ->
@@ -374,10 +300,9 @@ putBinary db wopts key val = put db wopts (binaryToBS key) (binaryToBS val)
 
 -- | Write a key/value pair.
 put :: (MonadIO m, HasCallStack) => DB -> WriteOptions -> ByteString -> ByteString -> m ()
-put db@DB{ db_fptr } opts key value = liftIO $ withCWriteOpts opts $ \opts_ptr -> do
+put db@DB{ db_ptr } opts key value = liftIO $ withCWriteOpts opts $ \opts_ptr -> do
     ensureOpen db
-    withForeignPtr db_fptr $ \db_ptr ->
-        BU.unsafeUseAsCStringLen key   $ \(key_ptr, klen) ->
+    BU.unsafeUseAsCStringLen key   $ \(key_ptr, klen) ->
         BU.unsafeUseAsCStringLen value $ \(val_ptr, vlen) ->
             throwIfErr "put"
                 $ c_rocksdb_put db_ptr opts_ptr
@@ -392,10 +317,9 @@ getBinary db ropts key = fmap bsToBinary <$> get db ropts (binaryToBS key)
 
 -- | Read a value by key.
 get :: (MonadIO m, HasCallStack) => DB -> ReadOptions -> ByteString -> m (Maybe ByteString)
-get db@DB{ db_fptr } opts key = liftIO $ withCReadOpts opts $ \opts_ptr -> do
+get db@DB{ db_ptr } opts key = liftIO $ withCReadOpts opts $ \opts_ptr -> do
     ensureOpen db
-    withForeignPtr db_fptr $ \db_ptr ->
-        BU.unsafeUseAsCStringLen key $ \(key_ptr, klen) ->
+    BU.unsafeUseAsCStringLen key $ \(key_ptr, klen) ->
         alloca                       $ \vlen_ptr -> do
             val_ptr <- throwIfErr "get" $
                 c_rocksdb_get db_ptr opts_ptr key_ptr (intToCSize klen) vlen_ptr
@@ -409,19 +333,17 @@ get db@DB{ db_fptr } opts key = liftIO $ withCReadOpts opts $ \opts_ptr -> do
 
 -- | Delete a key/value pair.
 delete :: (MonadIO m, HasCallStack) => DB -> WriteOptions -> ByteString -> m ()
-delete db@DB{ db_fptr } opts key = liftIO $ withCWriteOpts opts $ \opts_ptr -> do
+delete db@DB{ db_ptr } opts key = liftIO $ withCWriteOpts opts $ \opts_ptr -> do
     ensureOpen db
-    withForeignPtr db_fptr $ \db_ptr ->
-        BU.unsafeUseAsCStringLen key $ \(key_ptr, klen) ->
-            throwIfErr "delete"
-                $ c_rocksdb_delete db_ptr opts_ptr key_ptr (intToCSize klen)
+    BU.unsafeUseAsCStringLen key $ \(key_ptr, klen) ->
+        throwIfErr "delete"
+            $ c_rocksdb_delete db_ptr opts_ptr key_ptr (intToCSize klen)
 
 -- | Perform a batch mutation.
 write :: (MonadIO m, HasCallStack) => DB -> WriteOptions -> WriteBatch -> m ()
-write db@DB{ db_fptr } opts batch = liftIO $ withCWriteOpts opts $ \opts_ptr -> do
+write db@DB{ db_ptr } opts batch = liftIO $ withCWriteOpts opts $ \opts_ptr -> do
     ensureOpen db
-    withForeignPtr db_fptr $ \db_ptr ->
-        bracket c_rocksdb_writebatch_create c_rocksdb_writebatch_destroy $ \batch_ptr -> do
+    bracket c_rocksdb_writebatch_create c_rocksdb_writebatch_destroy $ \batch_ptr -> do
 
         mapM_ (batchAdd batch_ptr) batch
 

--- a/src/Database/RocksDB/Base.hs
+++ b/src/Database/RocksDB/Base.hs
@@ -133,6 +133,13 @@ createSnapshotBracket db = allocate (createSnapshot db) (releaseSnapshot db)
 -- | Open a database.
 --
 -- The returned handle should be released with 'close'.
+--
+-- This function is not async-exception-safe.
+-- If interrupted by an async exceptions, the resources acquired
+-- by this function will memory-leak.
+-- Thus it should be used only within `bracket` or a similar function
+-- so that a finalizer calling `close` can be attached while async
+-- exceptions are disabled.
 open :: MonadIO m => FilePath -> Options -> m DB
 open path opts = liftIO $ bracketOnError initialize finalize mkDB
     where

--- a/src/Database/RocksDB/C.hsc
+++ b/src/Database/RocksDB/C.hsc
@@ -67,6 +67,9 @@ foreign import ccall safe "rocksdb\\c.h rocksdb_open"
 foreign import ccall safe "rocksdb\\c.h rocksdb_close"
   c_rocksdb_close :: RocksDBPtr -> IO ()
 
+foreign import ccall safe "rocksdb\\c.h &rocksdb_close"
+  c_rocksdb_close_funptr :: FunPtr (RocksDBPtr -> IO ())
+
 
 foreign import ccall safe "rocksdb\\c.h rocksdb_put"
   c_rocksdb_put :: RocksDBPtr

--- a/src/Database/RocksDB/Internal.hs
+++ b/src/Database/RocksDB/Internal.hs
@@ -99,14 +99,13 @@ data DBHandleStatus
 -- via the `db->...` pointer in the RocksDB implementation will be invalid
 -- (see e.g. https://github.com/facebook/rocksdb/blob/75d57a5d538/db/c.cc#L736).
 data DB = DB
-    { db_fptr :: ForeignPtr RocksDB
+    { db_ptr :: RocksDBPtr
     , dbOptions :: Options'
     , dbHandleStatusRef :: IORef DBHandleStatus
-    , dbAutoclose :: Bool
     }
 
 instance Eq DB where
-    (DB pt1 _ _ _) == (DB pt2 _ _ _) = pt1 == pt2
+    (DB pt1 _ _) == (DB pt2 _ _) = pt1 == pt2
 
 -- | Internal representation of a 'Comparator'
 data Comparator' = Comparator' (FunPtr CompareFun)

--- a/src/Database/RocksDB/Iterator.hs
+++ b/src/Database/RocksDB/Iterator.hs
@@ -75,7 +75,7 @@ withIterator db opts f = do
 
 -- | Create an 'Iterator'.
 --
--- The iterator will be released when the enclosing 'runResourceT' terminates.
+-- The iterator will be released when the enclosing 'runResourceTChecked' terminates.
 -- You may consider to use 'iterOpen'' instead and manually release the iterator
 -- as soon as it is no longer needed (alternatively, use 'withIterator').
 --

--- a/src/Database/RocksDB/Iterator.hs
+++ b/src/Database/RocksDB/Iterator.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NamedFieldPuns #-}
 -- |
 -- Module      : Database.RocksDB.Iterator
 -- Copyright   : (c) 2012-2013 The leveldb-haskell Authors
@@ -96,12 +97,14 @@ iterOpenBracket db opts = allocate (createIter db opts) releaseIter
 -- updates written after the iterator was created are not visible. You may,
 -- however, specify an older 'Snapshot' in the 'ReadOptions'.
 createIter :: MonadIO m => DB -> ReadOptions -> m Iterator
-createIter (DB db_ptr _) opts = liftIO $ do
+createIter db@DB{ db_fptr } opts = liftIO $ do
+    ensureOpen db
     opts_ptr <- mkCReadOpts opts
-    flip onException (freeCReadOpts opts_ptr) $ do
-        iter_ptr <- throwErrnoIfNull "create_iterator" $
-                        c_rocksdb_create_iterator db_ptr opts_ptr
-        return $ Iterator iter_ptr opts_ptr
+    withForeignPtr db_fptr $ \db_ptr -> do
+        flip onException (freeCReadOpts opts_ptr) $ do
+            iter_ptr <- throwErrnoIfNull "create_iterator" $
+                            c_rocksdb_create_iterator db_ptr opts_ptr
+            return $ Iterator iter_ptr opts_ptr
 
 -- | Release an 'Iterator'.
 --

--- a/src/Database/RocksDB/Iterator.hs
+++ b/src/Database/RocksDB/Iterator.hs
@@ -97,14 +97,13 @@ iterOpenBracket db opts = allocate (createIter db opts) releaseIter
 -- updates written after the iterator was created are not visible. You may,
 -- however, specify an older 'Snapshot' in the 'ReadOptions'.
 createIter :: MonadIO m => DB -> ReadOptions -> m Iterator
-createIter db@DB{ db_fptr } opts = liftIO $ do
+createIter db@DB{ db_ptr } opts = liftIO $ do
     ensureOpen db
     opts_ptr <- mkCReadOpts opts
-    withForeignPtr db_fptr $ \db_ptr -> do
-        flip onException (freeCReadOpts opts_ptr) $ do
-            iter_ptr <- throwErrnoIfNull "create_iterator" $
-                            c_rocksdb_create_iterator db_ptr opts_ptr
-            return $ Iterator iter_ptr opts_ptr
+    flip onException (freeCReadOpts opts_ptr) $ do
+        iter_ptr <- throwErrnoIfNull "create_iterator" $
+                        c_rocksdb_create_iterator db_ptr opts_ptr
+        return $ Iterator iter_ptr opts_ptr
 
 -- | Release an 'Iterator'.
 --

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,7 +10,7 @@ extra-deps:
                     #'UnicodeString' (2.10.1 is the first) is available in LTS.
 # Remove once https://github.com/snoyberg/conduit/pull/347 (1.1.11) is available in LTS
 - git: https://github.com/snoyberg/conduit.git
-  commit: fbfedcf48f30909cc22abd37b0220ba6fbbb5acf
+  commit: d90f4ddeec60022fa8070af58a8d1f6aa17c9f39
   subdirs:
   - resourcet
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,6 +8,11 @@ packages:
 extra-deps:
 - QuickCheck-2.10.1 #This is only until a version of 'QuickCheck' that exports
                     #'UnicodeString' (2.10.1 is the first) is available in LTS.
+# Remove once https://github.com/snoyberg/conduit/pull/347 (1.1.11) is available in LTS
+- git: https://github.com/snoyberg/conduit.git
+  commit: fbfedcf48f30909cc22abd37b0220ba6fbbb5acf
+  subdirs:
+  - resourcet
 
 resolver: lts-9.14
 

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -11,7 +11,7 @@ import           System.IO.Temp               (withSystemTempDirectory)
 
 import           Database.RocksDB             (Compression (..), DB, compression,
                                                createIfMissing, defaultOptions, get, open,
-                                               put)
+                                               put, close)
 
 import           Test.Hspec                   (describe, hspec, it, shouldReturn)
 import           Test.QuickCheck              (Arbitrary (..), UnicodeString (..),
@@ -32,7 +32,9 @@ main =  hspec $ do
       runResourceT $ withSystemTempDirectory "rocksdb" $ \path -> do
         db <- initializeDB path
         put db def "zzz" "zzz"
-        get db def "zzz"
+        val <- get db def "zzz"
+        close db
+        return val
       `shouldReturn` (Just "zzz")
 
     it "should put items into a database whose filepath has unicode characters and\
@@ -41,5 +43,7 @@ main =  hspec $ do
         unicode <- getUnicodeString <$> liftIO (generate arbitrary)
         db <- initializeDB $ path </> "unicode-randomdir-" ++ unicode
         put db def "zzz" "zzz"
-        get db def "zzz"
+        val <- get db def "zzz"
+        close db
+        return val
       `shouldReturn` (Just "zzz")

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -16,8 +16,8 @@ import           System.IO.Error              (ioeGetErrorType, isUserErrorType,
 import           System.IO.Temp               (withSystemTempDirectory)
 
 import           Database.RocksDB             (Compression (..), Options (..),
-                                               createIfMissing, defaultOptions, get, withDB, open, openBracket, openAutoclose,
-                                               put, close, finalize)
+                                               createIfMissing, defaultOptions, get, withDB, open, openBracket,
+                                               put, close)
 
 import           Test.Hspec                   (describe, hspec, it, shouldReturn, shouldThrow)
 import           Test.QuickCheck              (Arbitrary (..), UnicodeString (..),
@@ -41,7 +41,7 @@ main =  hspec $ do
           return val
       `shouldReturn` (Just "zzz")
 
-    it "should put items into the database and retrieve them (non-asysnc-safe way)" $ do
+    it "should put items into the database and retrieve them (non-async-safe way)" $ do
       withSystemTempDirectory "rocksdb" $ \path -> do
         db <- open path testOpenOptions
         put db def "zzz" "zzz"
@@ -59,21 +59,6 @@ main =  hspec $ do
         return val
       `shouldReturn` (Just "zzz")
 
-    it "should put items into the database and retrieve them (autoclose way)" $ do
-      -- [Note: Unique tmp dirs for autoclose without finalize]
-      -- We need to use a different temp dir prefix here that we don't reuse
-      -- anywhere else, because the GC can delay `close`ing the DB for
-      -- arbitrarily long, and RocksDB has a lock check that would make
-      -- using this directory again fail before `close` is called;
-      -- so later tests using the same dir would fail.
-      -- See comment on `openAutoclose`.
-      withSystemTempDirectory "rocksdb-autoclose-uniquedir1" $ \path -> do
-        db <- openAutoclose path testOpenOptions
-        put db def "zzz" "zzz"
-        val <- get db def "zzz"
-        return val
-      `shouldReturn` (Just "zzz")
-
     it "does weird global singleton string matching stuff for double-locking warnings" $ do
       -- This test will fail when RocksDB fixes this issue
       -- (see https://stackoverflow.com/questions/37310588/rocksdb-io-error-lock-no-locks-available#comment83145041_37312033).
@@ -85,23 +70,23 @@ main =  hspec $ do
 
       createDirectoryIfMissing True path
 
+      db <- open path testOpenOptions
       (do
-        db <- open path testOpenOptions
         put db def "zzz" "zzz"
         get db def "zzz") `shouldReturn` (Just "zzz")
       -- We purposely don't `close` the DB above.
 
       removeDirectoryRecursive path
 
-      (do
-        db <- open path testOpenOptions
-        put db def "zzz" "zzz"
-        get db def "zzz") `shouldThrow` \ioe ->
-          isUserErrorType (ioeGetErrorType ioe) &&
-          ioeGetErrorString ioe `elem`
-            [ "open: IO error: lock " ++ path ++ "/LOCK: No locks available"
-            , "open: IO error: While lock file: " ++ path ++ "/LOCK: No locks available"
-            ]
+      open path testOpenOptions `shouldThrow` \ioe ->
+        isUserErrorType (ioeGetErrorType ioe) &&
+        ioeGetErrorString ioe `elem`
+          [ "open: IO error: lock " ++ path ++ "/LOCK: No locks available"
+          , "open: IO error: While lock file: " ++ path ++ "/LOCK: No locks available"
+          ]
+
+      -- Close first DB now so that it doesn't memory-leak.
+      close db
 
     it "should put items into a database whose filepath has unicode characters and\
        \ retrieve them" $ do
@@ -123,23 +108,6 @@ main =  hspec $ do
           close db
           return val
       `shouldThrow` (\(ErrorCall str) -> str == "haskell-rocksdb ensureOpenAndClose: Caller BUG: DB is closed")
-
-    it "should detect manual close after openAutoclose" $ do
-      -- See Note "Unique tmp dirs for autoclose without finalize".
-      withSystemTempDirectory "rocksdb-autoclose-uniquedir2" $ \path -> do
-        db <- openAutoclose path testOpenOptions
-        put db def "zzz" "zzz"
-        val <- get db def "zzz"
-        close db
-        return val
-      `shouldThrow` (\(ErrorCall str) -> str == "haskell-rocksdb close: Caller BUG: DB opened with 'openAutoclose' must not be closed manually")
-
-    it "should not trigger after orderly manual finalize" $ do
-      withSystemTempDirectory "rocksdb" $ \path -> do
-        db <- openAutoclose path testOpenOptions
-        put db def "zzz" "zzz"
-        _val <- get db def "zzz"
-        finalize db :: IO ()
 
   describe "multi-thread crash checks" $ do
 

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -6,6 +6,7 @@ module Main where
 import           Control.Monad.IO.Class       (MonadIO (liftIO))
 import           Control.Monad.Trans.Resource (MonadResource, runResourceT)
 import           Data.Default                 (def)
+import           System.FilePath              ((</>))
 import           System.IO.Temp               (withSystemTempDirectory)
 
 import           Database.RocksDB             (Compression (..), DB, compression,
@@ -38,7 +39,7 @@ main =  hspec $ do
        \ retrieve them" $  do
       runResourceT $ withSystemTempDirectory "rocksdb" $ \path -> do
         unicode <- getUnicodeString <$> liftIO (generate arbitrary)
-        db <- initializeDB $ path ++ unicode
+        db <- initializeDB $ path </> "unicode-randomdir-" ++ unicode
         put db def "zzz" "zzz"
         get db def "zzz"
       `shouldReturn` (Just "zzz")

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE BinaryLiterals      #-}
 {-# LANGUAGE OverloadedStrings   #-}
 
@@ -59,6 +60,9 @@ main =  hspec $ do
         return val
       `shouldReturn` (Just "zzz")
 
+    -- This test doesn't apply to Windows because there we can't delete the
+    -- directory while a file in it is open.
+#if !defined(mingw32_HOST_OS)
     it "does weird global singleton string matching stuff for double-locking warnings" $ do
       -- This test will fail when RocksDB fixes this issue
       -- (see https://stackoverflow.com/questions/37310588/rocksdb-io-error-lock-no-locks-available#comment83145041_37312033).
@@ -87,9 +91,9 @@ main =  hspec $ do
 
       -- Close first DB now so that it doesn't memory-leak.
       close db
+#endif
 
-    it "should put items into a database whose filepath has unicode characters and\
-       \ retrieve them" $ do
+    it "should put items into a database whose filepath has unicode characters and retrieve them" $ do
       runResourceT $ withSystemTempDirectory "rocksdb" $ \path -> do
         unicode <- getUnicodeString <$> liftIO (generate arbitrary)
         (_, db) <- openBracket (path </> "unicode-randomdir-" ++ unicode) testOpenOptions

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -3,17 +3,20 @@
 
 module Main where
 
+import           Control.Monad                (when)
 import           Control.Monad.IO.Class       (MonadIO (liftIO))
 import           Control.Monad.Trans.Resource (runResourceT)
 import           Data.Default                 (def)
+import           System.Directory             (createDirectoryIfMissing, doesDirectoryExist, removeDirectoryRecursive)
 import           System.FilePath              ((</>))
+import           System.IO.Error              (ioeGetErrorType, isUserErrorType, ioeGetErrorString)
 import           System.IO.Temp               (withSystemTempDirectory)
 
 import           Database.RocksDB             (Compression (..), DB, compression,
                                                createIfMissing, defaultOptions, get, open,
                                                put, close)
 
-import           Test.Hspec                   (describe, hspec, it, shouldReturn)
+import           Test.Hspec                   (describe, hspec, it, shouldReturn, shouldThrow)
 import           Test.QuickCheck              (Arbitrary (..), UnicodeString (..),
                                                generate)
 
@@ -36,6 +39,32 @@ main =  hspec $ do
         close db
         return val
       `shouldReturn` (Just "zzz")
+
+    it "does weird global singleton string matching stuff for double-locking warnings" $ do
+      -- This test will fail when RocksDB fixes this issue
+      -- (see https://stackoverflow.com/questions/37310588/rocksdb-io-error-lock-no-locks-available#comment83145041_37312033).
+      -- It exists so that we get notified when that fixing happens.
+      let path = "/tmp/tmpdir"
+
+      exists <- doesDirectoryExist path
+      when exists $ removeDirectoryRecursive path
+
+      createDirectoryIfMissing True path
+
+      (runResourceT $ do
+        db <- initializeDB path
+        put db def "zzz" "zzz"
+        get db def "zzz") `shouldReturn` (Just "zzz")
+      -- We purposely don't `close` the DB above.
+
+      removeDirectoryRecursive path
+
+      (runResourceT $ do
+        db <- initializeDB path
+        put db def "zzz" "zzz"
+        get db def "zzz") `shouldThrow` \ioe ->
+          isUserErrorType (ioeGetErrorType ioe) &&
+          ioeGetErrorString ioe == ("open: IO error: lock " ++ path ++ "/LOCK: No locks available")
 
     it "should put items into a database whose filepath has unicode characters and\
        \ retrieve them" $  do

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -5,6 +5,7 @@ module Main where
 
 import           Control.Concurrent           (threadDelay)
 import           Control.Concurrent.Async     (race_)
+import           Control.Exception            (ErrorCall(..))
 import           Control.Monad                (when)
 import           Control.Monad.IO.Class       (MonadIO (liftIO))
 import           Control.Monad.Trans.Resource (runResourceT)
@@ -14,31 +15,62 @@ import           System.FilePath              ((</>))
 import           System.IO.Error              (ioeGetErrorType, isUserErrorType, ioeGetErrorString)
 import           System.IO.Temp               (withSystemTempDirectory)
 
-import           Database.RocksDB             (Compression (..), DB, compression,
-                                               createIfMissing, defaultOptions, get, open,
-                                               put, close)
+import           Database.RocksDB             (Compression (..), Options (..),
+                                               createIfMissing, defaultOptions, get, withDB, open, openBracket, openAutoclose,
+                                               put, close, finalize)
 
 import           Test.Hspec                   (describe, hspec, it, shouldReturn, shouldThrow)
 import           Test.QuickCheck              (Arbitrary (..), UnicodeString (..),
                                                generate)
 
-initializeDB :: MonadIO m => FilePath -> m DB
-initializeDB path =
-    open
-        path
-        defaultOptions
-        {createIfMissing = True, compression = NoCompression}
+testOpenOptions :: Options
+testOpenOptions =
+  defaultOptions
+    {createIfMissing = True, compression = NoCompression}
 
 main :: IO ()
 main =  hspec $ do
 
   describe "Basic DB Functionality" $ do
-    it "should put items into the database and retrieve them" $  do
-      runResourceT $ withSystemTempDirectory "rocksdb" $ \path -> do
-        db <- initializeDB path
+
+    it "should put items into the database and retrieve them (withDB way)" $ do
+      withSystemTempDirectory "rocksdb" $ \path -> do
+        withDB path testOpenOptions $ \db -> do
+          put db def "zzz" "zzz"
+          val <- get db def "zzz"
+          return val
+      `shouldReturn` (Just "zzz")
+
+    it "should put items into the database and retrieve them (non-asysnc-safe way)" $ do
+      withSystemTempDirectory "rocksdb" $ \path -> do
+        db <- open path testOpenOptions
         put db def "zzz" "zzz"
         val <- get db def "zzz"
         close db
+        return val
+      `shouldReturn` (Just "zzz")
+
+    it "should put items into the database and retrieve them (MonadResource way)" $ do
+      runResourceT $ withSystemTempDirectory "rocksdb" $ \path -> do
+        (_, db) <- openBracket path testOpenOptions
+        put db def "zzz" "zzz"
+        val <- get db def "zzz"
+        close db -- TODO remove; this should make the test fail, but it doesn't because errors in finalizers run by runResourceT don't seem to bubble up
+        return val
+      `shouldReturn` (Just "zzz")
+
+    it "should put items into the database and retrieve them (autoclose way)" $ do
+      -- [Note: Unique tmp dirs for autoclose without finalize]
+      -- We need to use a different temp dir prefix here that we don't reuse
+      -- anywhere else, because the GC can delay `close`ing the DB for
+      -- arbitrarily long, and RocksDB has a lock check that would make
+      -- using this directory again fail before `close` is called;
+      -- so later tests using the same dir would fail.
+      -- See comment on `openAutoclose`.
+      withSystemTempDirectory "rocksdb-autoclose-uniquedir1" $ \path -> do
+        db <- openAutoclose path testOpenOptions
+        put db def "zzz" "zzz"
+        val <- get db def "zzz"
         return val
       `shouldReturn` (Just "zzz")
 
@@ -53,42 +85,67 @@ main =  hspec $ do
 
       createDirectoryIfMissing True path
 
-      (runResourceT $ do
-        db <- initializeDB path
+      (do
+        db <- open path testOpenOptions
         put db def "zzz" "zzz"
         get db def "zzz") `shouldReturn` (Just "zzz")
       -- We purposely don't `close` the DB above.
 
       removeDirectoryRecursive path
 
-      (runResourceT $ do
-        db <- initializeDB path
+      (do
+        db <- open path testOpenOptions
         put db def "zzz" "zzz"
         get db def "zzz") `shouldThrow` \ioe ->
           isUserErrorType (ioeGetErrorType ioe) &&
-          ioeGetErrorString ioe == ("open: IO error: lock " ++ path ++ "/LOCK: No locks available")
+          ioeGetErrorString ioe `elem`
+            [ "open: IO error: lock " ++ path ++ "/LOCK: No locks available"
+            , "open: IO error: While lock file: " ++ path ++ "/LOCK: No locks available"
+            ]
 
     it "should put items into a database whose filepath has unicode characters and\
-       \ retrieve them" $  do
+       \ retrieve them" $ do
       runResourceT $ withSystemTempDirectory "rocksdb" $ \path -> do
         unicode <- getUnicodeString <$> liftIO (generate arbitrary)
-        db <- initializeDB $ path </> "unicode-randomdir-" ++ unicode
+        (_, db) <- openBracket (path </> "unicode-randomdir-" ++ unicode) testOpenOptions
+        put db def "zzz" "zzz"
+        val <- get db def "zzz"
+        return val
+      `shouldReturn` (Just "zzz")
+
+  describe "double-close detection" $ do
+
+    it "should detect manual close within withDB" $ do
+      withSystemTempDirectory "rocksdb" $ \path -> do
+        withDB path testOpenOptions $ \db -> do
+          put db def "zzz" "zzz"
+          val <- get db def "zzz"
+          close db
+          return val
+      `shouldThrow` (\(ErrorCall str) -> str == "haskell-rocksdb ensureOpenAndClose: Caller BUG: DB is closed")
+
+    it "should detect manual close after openAutoclose" $ do
+      -- See Note "Unique tmp dirs for autoclose without finalize".
+      withSystemTempDirectory "rocksdb-autoclose-uniquedir2" $ \path -> do
+        db <- openAutoclose path testOpenOptions
         put db def "zzz" "zzz"
         val <- get db def "zzz"
         close db
         return val
-      `shouldReturn` (Just "zzz")
+      `shouldThrow` (\(ErrorCall str) -> str == "haskell-rocksdb close: Caller BUG: DB opened with 'openAutoclose' must not be closed manually")
+
+    it "should not trigger after orderly manual finalize" $ do
+      withSystemTempDirectory "rocksdb" $ \path -> do
+        db <- openAutoclose path testOpenOptions
+        put db def "zzz" "zzz"
+        _val <- get db def "zzz"
+        finalize db :: IO ()
 
   describe "multi-thread crash checks" $ do
 
-    it "should not segfault on use-after-close" $ do
+    it "should not segfault on use-after-close, should error instead" $ do
       withSystemTempDirectory "rocksdb" $ \path -> do
-        db <-
-          open
-            path
-            defaultOptions
-            {createIfMissing = True, compression = NoCompression}
-
+        db <- open path testOpenOptions
         race_
           (do
             put db def "key" "value1"
@@ -100,3 +157,4 @@ main =  hspec $ do
             put db def "key" "value2"
             close db
           )
+        `shouldThrow` (\(ErrorCall str) -> str == "haskell-rocksdb ensureOpen: Caller BUG: DB is closed")

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -4,7 +4,7 @@
 module Main where
 
 import           Control.Monad.IO.Class       (MonadIO (liftIO))
-import           Control.Monad.Trans.Resource (MonadResource, runResourceT)
+import           Control.Monad.Trans.Resource (runResourceT)
 import           Data.Default                 (def)
 import           System.FilePath              ((</>))
 import           System.IO.Temp               (withSystemTempDirectory)
@@ -17,7 +17,7 @@ import           Test.Hspec                   (describe, hspec, it, shouldReturn
 import           Test.QuickCheck              (Arbitrary (..), UnicodeString (..),
                                                generate)
 
-initializeDB :: MonadResource m => FilePath -> m DB
+initializeDB :: MonadIO m => FilePath -> m DB
 initializeDB path =
     open
         path


### PR DESCRIPTION
The IOHK devops team has complained that incorrect usage of this library can result in hard crashes (segmentation faults) that can be hard to debug.

The changes in this PR turn most of the errors that arise from incorrect usage (such as calling `close` twice) from segmentation faults into Haskell exceptions with a helpful error message.

Further:

* I've added a bunch of tests that show how the various ways to open and close DBs fail
* I've added lots of Haddocks to the `open*`/`close` functions so that callers are aware how they fail
* I have added `HasCallStack` constraints to many functions that can fail (such as `close`), so that when an exception arises, users can easily see where it `close` was used incorrectly
* I've added `withDB` as a simple bracket-style function; ideally most users could use that and never call `close` manually, like for example:

```
main = do
  ...
  withDB path options $ \db -> do
    ... all program code, never calling `close` ...
```
  