### PR TITLE
Exported 2 functions for usage in batch writes

### DIFF
--- a/src/Database/RocksDB/Base.hs
+++ b/src/Database/RocksDB/Base.hs
@@ -63,6 +63,10 @@ module Database.RocksDB.Base
     , repair
     , approximateSize
 
+    -- * Utility functions to help perform mass writes
+    , binaryToBS
+    , bsToBinary
+
     -- * Iteration
     , module Database.RocksDB.Iterator
     ) where


### PR DESCRIPTION
`Data.Binary.encode` produces `Bytestring` of wrong type.
So, no way to pack some `Binary x` into `Put` constructor for batch writes, except by writting these functions by hand.